### PR TITLE
ignore the JESftp.cfg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.py[co]
-
+.JESftp.cfg
 # Packages
 *.egg
 *.egg-info

--- a/JESftp.py
+++ b/JESftp.py
@@ -73,7 +73,7 @@ class JESftp:
          self.port = conn_str[1]
       else:
         self.server = conn_str[0]
-        self.port = 22
+        self.port = 21
       ##
       
       


### PR DESCRIPTION
I think it makes sense to ignore the generated config file. Added it to .gitignore.
